### PR TITLE
Add constructor to use custom Wire interface

### DIFF
--- a/Ezo_i2c.cpp
+++ b/Ezo_i2c.cpp
@@ -13,6 +13,10 @@ Ezo_board::Ezo_board(uint8_t address, const char* name){
 	this->name = name;
 }
 
+Ezo_board::Ezo_board(uint8_t address, TwoWire* wire) : Ezo_board(address){
+  this->wire = wire;
+}
+
 const char* Ezo_board::get_name(){
 	return this->name;
 }
@@ -30,9 +34,9 @@ void Ezo_board::set_address(uint8_t address){
 }
 
 void Ezo_board::send_cmd(const char* command) {
-  Wire.beginTransmission(this->i2c_address);
-  Wire.write(command); 
-  Wire.endTransmission();
+  wire->beginTransmission(this->i2c_address);
+  wire->write(command);
+  wire->endTransmission();
   this->issued_read = false;
 }
 
@@ -88,15 +92,15 @@ enum Ezo_board::errors Ezo_board::receive_cmd( char * sensordata_buffer, uint8_t
 
   memset(sensordata_buffer, 0, buffer_len);        // clear sensordata array;
 
-  Wire.requestFrom(this->i2c_address, (uint8_t)(buffer_len-1), (uint8_t)1);
-  code = Wire.read();
+  wire->requestFrom(this->i2c_address, (uint8_t)(buffer_len-1), (uint8_t)1);
+  code = wire->read();
 
-  //Wire.beginTransmission(this->i2c_address);
-  while (Wire.available()) {
-    in_char = Wire.read();
+  //wire->beginTransmission(this->i2c_address);
+  while (wire->available()) {
+    in_char = wire->read();
 
     if (in_char == 0) {
-      //Wire.endTransmission();
+      //wire->endTransmission();
       break;
     }
     else {

--- a/Ezo_i2c.h
+++ b/Ezo_i2c.h
@@ -41,6 +41,7 @@ class Ezo_board{
 	Ezo_board(uint8_t address);	 //Takes I2C address of the device
 	Ezo_board(uint8_t address, const char* name); //Takes I2C address of the device
 												//as well a name of your choice
+	Ezo_board(uint8_t address, TwoWire* wire); //Takes I2C address and TwoWire interface
 	
 	void send_cmd(const char* command);	
 	//send any command in a string, see the devices datasheet for available i2c commands
@@ -99,6 +100,7 @@ class Ezo_board{
 	bool issued_read = false;
 	enum errors error;	
 	const static uint8_t bufferlen = 32;
+	TwoWire* wire = &Wire;
 };
 
 


### PR DESCRIPTION
Why:

- Allows to select either of the ESP32 I2C interfaces

This change addresses the need by:

- Adding a new constructor
- Changing the internal Wire object to a pointer