### PR TITLE
Fix broken wire reference in send_cmd

### DIFF
--- a/Ezo_i2c.cpp
+++ b/Ezo_i2c.cpp
@@ -38,13 +38,13 @@ void Ezo_board::set_address(uint8_t address){
 }
 
 void Ezo_board::send_cmd(const char* command) {
-  Wire.beginTransmission(this->i2c_address);
+  wire->beginTransmission(this->i2c_address);
   #ifdef ESP32
-  Wire.write((const uint8_t*)command, strlen(command)); 
+  wire->write((const uint8_t*)command, strlen(command));
   #else
-  Wire.write(command); 
+  wire->write(command);
   #endif
-  Wire.endTransmission();
+  wire->endTransmission();
   this->issued_read = false;
 }
 


### PR DESCRIPTION
Previously the send_cmd function was hard coded to use `Wire`:

```
void Ezo_board::send_cmd(const char* command) {
  Wire.beginTransmission(this->i2c_address);
  #ifdef ESP32
  Wire.write((const uint8_t*)command, strlen(command)); 
  #else
  Wire.write(command); 
  #endif
  Wire.endTransmission();
  this->issued_read = false;
}
```

However the library is setup to accept a Wire interface in one of its constructors:

```
Ezo_board::Ezo_board(uint8_t address, TwoWire* wire) : Ezo_board(address){
  this->wire = wire;
}
```

So if you use the constructor shown above, the library cannot possibly work.